### PR TITLE
Cast passlen to uintmax_t

### DIFF
--- a/io.c
+++ b/io.c
@@ -426,7 +426,7 @@ read_passphrase(const char *prompt, char *pass, size_t passlen, size_t bufsz, ti
 	/* Warn about passphrase trimming */
 	if (strlen(pass) > MAX_PASSSZ)
 		tc_log(0, "WARNING: Passphrase is being trimmed to %ju "
-		    "characters, discarding rest.\n", passlen);
+		    "characters, discarding rest.\n", (uintmax_t) passlen);
 
 	/* Cut off after passlen characters */
 	pass[passlen] = '\0';


### PR DESCRIPTION
Without the cast the program reports numbers like "13804910425701089344" as the maximum passphrase length.
