### PR TITLE
Report the correct maximum passphrase length

### DIFF
--- a/io.c
+++ b/io.c
@@ -425,7 +425,7 @@ read_passphrase(const char *prompt, char *pass, size_t passlen, size_t bufsz, ti
 
 	/* Warn about passphrase trimming */
 	if (strlen(pass) > MAX_PASSSZ)
-		tc_log(0, "WARNING: Passphrase is being trimmed to %ju "
+		tc_log(0, "WARNING: Passphrase is being trimmed to %zu "
 		    "characters, discarding rest.\n", passlen);
 
 	/* Cut off after passlen characters */


### PR DESCRIPTION
With the wrong format specifier the program reports numbers like "13804910425701089344" as the maximum passphrase length.
