### PR TITLE
Clean up manpages

### DIFF
--- a/tcplay.3
+++ b/tcplay.3
@@ -45,6 +45,7 @@
 .Nm tc_api_task_get_error
 .Nd TrueCrypt volume management
 .Sh LIBRARY
+.ds doc-str-Lb-libtcplay TrueCrypt volume management (libtcplay, \-ltcplay)
 .Lb libtcplay
 .Sh SYNOPSIS
 .In tcplay_api.h

--- a/tcplay.3
+++ b/tcplay.3
@@ -180,7 +180,7 @@ does, but without changing the passphrase, keyfiles or PRF algorithm.
 .Pp
 The
 .Fn tc_api_task_set
-function allows settting a number of different options for the current task.
+function allows setting a number of different options for the current task.
 The following table shows which keys are available on calls to
 .Fn tc_api_task_set
 for each of the operations.
@@ -536,7 +536,7 @@ to indicate that the operation completed successfully, or
 to indicate that the operation is not implemented
 , or
 .Dv TC_ERR
-to indicate that any other error occured.
+to indicate that any other error occurred.
 .Pp
 The
 .Fn tc_api_task_get_error

--- a/tcplay.8
+++ b/tcplay.8
@@ -360,7 +360,7 @@ volume.
 Which volume is accessed solely depends on the passphrase and keyfile(s)
 used.
 If the passphrase and keyfiles for the outer volume are specified,
-no information about the existance of the hidden volume is exposed.
+no information about the existence of the hidden volume is exposed.
 Without knowledge of the passphrase and keyfile(s) of the hidden volume
 its existence remains unexposed.
 The hidden volume can be protected when mapping the outer volume by
@@ -496,7 +496,7 @@ Or alternatively:
 .Nm Fl -unmap Ns = Ns Cm truecrypt2
 .Ed
 .Pp
-A hidden volume whose existance can be plausibly denied and its outer volume
+A hidden volume whose existence can be plausibly denied and its outer volume
 can for example be created with
 .Bd -ragged -offset indent
 .Nm Fl -create
@@ -522,7 +522,7 @@ and
 options.
 Which volume is later accessed depends only on which passphrase and keyfile(s)
 are being used,
-so that the existance of the hidden volume remains unknown without knowledge
+so that the existence of the hidden volume remains unknown without knowledge
 of the passphrase and keyfile it is protected by since it is located within
 the outer volume.
 To map the outer volume without potentially damaging the hidden volume,


### PR DESCRIPTION
I found some spelling errors and a complaint about library information in the manpages when trying to build tc-play  3.3 on a debian testing/unstable system.  These patches fix those errors.